### PR TITLE
Fix issue with masking nodata

### DIFF
--- a/indexing_script/datacube_indexing.sh
+++ b/indexing_script/datacube_indexing.sh
@@ -1,5 +1,7 @@
 datacube system init
 
+datacube-ows-update --schema
+
 datacube product add /src/products/sentinel1/s1_pyrosar_gamma_backscatter.yml
 
 for dir in /src/data/sentinel1/pyrosar/gamma/*/; do find "$dir" -type f -name "*.yaml"; done | while read -r file; do datacube dataset add https://deant-data-public-dev.s3.ap-southeast-2.amazonaws.com/experimental/pyrosar-ew-rtc/${file#/src/data/sentinel1/pyrosar/gamma/}; done
@@ -7,8 +9,6 @@ for dir in /src/data/sentinel1/pyrosar/gamma/*/; do find "$dir" -type f -name "*
 datacube spindex create 3031
 
 datacube spindex update 3031
-
-datacube-ows-update --schema
 
 datacube-ows-update
 

--- a/ows_src/config/minimal_ows_config.py
+++ b/ows_src/config/minimal_ows_config.py
@@ -44,7 +44,7 @@ ows_cfg = {
                         "max_datasets": 12,
                     },
                     "image_processing": {
-                        "extent_mask_func": "datacube_ows.ogc_utils.mask_by_val",
+                        "extent_mask_func": "datacube_ows.ogc_utils.mask_by_nan",
                         "always_fetch_bands": [],
                         "manual_merge": False,
                     },

--- a/products/sentinel1/s1_pyrosar_gamma_backscatter.yml
+++ b/products/sentinel1/s1_pyrosar_gamma_backscatter.yml
@@ -15,9 +15,9 @@ load:
 measurements:
 - name: hh
   units: "1"
-  nodata: -99
+  nodata: "NaN"
   dtype: float32
 - name: hv
   units: "1"
-  nodata: -99
+  nodata: "NaN"
   dtype: float32


### PR DESCRIPTION
Update products to use nan as nodata value, and update OWS config to reflect this. The datasets used in the mvp now have overviews, so load much faster in web platforms.